### PR TITLE
Replacements via ghsed

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,9 +1,1 @@
-{
-  "directory": "bower_components",
-  "registry": {
-    "search": [
-      "http://registry.origami.ft.com",
-      "https://bower.herokuapp.com"
-    ]
-  }
-}
+{"directory":"bower_components","registry":{"search":["https://origami-bower-registry.ft.com","https://bower.herokuapp.com"]}}


### PR DESCRIPTION
Command invoked 2017-10-20T13:17:16.104Z with the following arguments:
```bash
$ ghsed s/http:\/\/registry.origami/https:\/\/origami-bower-registry/i ft-interactive/*/.bowerrc
```